### PR TITLE
Continually republish TFs from Spot

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -2304,4 +2304,4 @@ class SpotROS:
                 rate_hz.sleep()
 
         except rospy.ROSInterruptException as ros_e:
-            rospy.logwarn(f"[_publish_object_tf_loop] {ros_e}")
+            rospy.logwarn(f"[SpotROS._update_tf_loop] {ros_e}")


### PR DESCRIPTION
This branch updates the Spot ROS driver to republish its latest transforms from a separate continual thread.