### PR TITLE
Disable Constant Publishing of RGB-D Camera Data

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -2263,19 +2263,19 @@ class SpotROS:
             self.rates["mobility_params"],
         )
         rate_limited_motion_allowed = RateLimitedCall(self.publish_allow_motion, 10)
-        rate_publish_camera_images = RateLimitedCall(
-            self.publish_camera_images_callback,
-            max(0.0, self.rates.get("camera_images", 10)),
-        )
-        rate_publish_depth_images = RateLimitedCall(
-            self.publish_depth_images_callback,
-            max(0.0, self.rates.get("camera_images", 10)),
-        )
+        # rate_publish_camera_images = RateLimitedCall(
+        #     self.publish_camera_images_callback,
+        #     max(0.0, self.rates.get("camera_images", 10)),
+        # )
+        # rate_publish_depth_images = RateLimitedCall(
+        #     self.publish_depth_images_callback,
+        #     max(0.0, self.rates.get("camera_images", 10)),
+        # )
 
         # Retrieval and publication of images can take some time, so break it out into
         # its own thread. This could probably be sped up further by breaking into separate nodes.
-        camera_publish_thread = ThreadedFunctionLoop(rate_publish_camera_images, rate)
-        depth_publish_thread = ThreadedFunctionLoop(rate_publish_depth_images, rate)
+        # camera_publish_thread = ThreadedFunctionLoop(rate_publish_camera_images, rate)
+        # depth_publish_thread = ThreadedFunctionLoop(rate_publish_depth_images, rate)
         update_tasks_thread = ThreadedFunctionLoop(self.spot_wrapper.updateTasks, rate)
         feedback_thread = ThreadedFunctionLoop(rate_limited_feedback, rate)
         mobility_thread = ThreadedFunctionLoop(rate_limited_mobility_params, rate)

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -444,38 +444,38 @@ class SpotROS:
 
     def publish_camera_images_callback(self) -> None:
         image_bundle = self.spot_wrapper.spot_images.get_camera_images()
-        frontleft_image_msg, frontleft_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
-            image_bundle.frontleft,
-            self.spot_wrapper,
-        )
-        frontright_image_msg, frontright_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
-            image_bundle.frontright,
-            self.spot_wrapper,
-        )
-        left_image_msg, left_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
-            image_bundle.left,
-            self.spot_wrapper,
-        )
-        right_image_msg, right_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
-            image_bundle.right,
-            self.spot_wrapper,
-        )
-        back_image_msg, back_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
-            image_bundle.back,
-            self.spot_wrapper,
-        )
+        # frontleft_image_msg, frontleft_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+        #     image_bundle.frontleft,
+        #     self.spot_wrapper,
+        # )
+        # frontright_image_msg, frontright_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+        #     image_bundle.frontright,
+        #     self.spot_wrapper,
+        # )
+        # left_image_msg, left_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+        #     image_bundle.left,
+        #     self.spot_wrapper,
+        # )
+        # right_image_msg, right_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+        #     image_bundle.right,
+        #     self.spot_wrapper,
+        # )
+        # back_image_msg, back_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+        #     image_bundle.back,
+        #     self.spot_wrapper,
+        # )
 
-        self.frontleft_image_pub.publish(frontleft_image_msg)
-        self.frontright_image_pub.publish(frontright_image_msg)
-        self.left_image_pub.publish(left_image_msg)
-        self.right_image_pub.publish(right_image_msg)
-        self.back_image_pub.publish(back_image_msg)
+        # self.frontleft_image_pub.publish(frontleft_image_msg)
+        # self.frontright_image_pub.publish(frontright_image_msg)
+        # self.left_image_pub.publish(left_image_msg)
+        # self.right_image_pub.publish(right_image_msg)
+        # self.back_image_pub.publish(back_image_msg)
 
-        self.frontleft_image_info_pub.publish(frontleft_camera_info)
-        self.frontright_image_info_pub.publish(frontright_camera_info)
-        self.left_image_info_pub.publish(left_camera_info)
-        self.right_image_info_pub.publish(right_camera_info)
-        self.back_image_info_pub.publish(back_camera_info)
+        # self.frontleft_image_info_pub.publish(frontleft_camera_info)
+        # self.frontright_image_info_pub.publish(frontright_camera_info)
+        # self.left_image_info_pub.publish(left_camera_info)
+        # self.right_image_info_pub.publish(right_camera_info)
+        # self.back_image_info_pub.publish(back_camera_info)
 
         self.populate_camera_static_transforms(image_bundle.frontleft)
         self.populate_camera_static_transforms(image_bundle.frontright)
@@ -2263,10 +2263,10 @@ class SpotROS:
             self.rates["mobility_params"],
         )
         rate_limited_motion_allowed = RateLimitedCall(self.publish_allow_motion, 10)
-        # rate_publish_camera_images = RateLimitedCall(
-        #     self.publish_camera_images_callback,
-        #     max(0.0, self.rates.get("camera_images", 10)),
-        # )
+        rate_publish_camera_images = RateLimitedCall(
+            self.publish_camera_images_callback,
+            max(0.0, self.rates.get("camera_images", 10)),
+        )
         # rate_publish_depth_images = RateLimitedCall(
         #     self.publish_depth_images_callback,
         #     max(0.0, self.rates.get("camera_images", 10)),
@@ -2274,7 +2274,7 @@ class SpotROS:
 
         # Retrieval and publication of images can take some time, so break it out into
         # its own thread. This could probably be sped up further by breaking into separate nodes.
-        # camera_publish_thread = ThreadedFunctionLoop(rate_publish_camera_images, rate)
+        camera_publish_thread = ThreadedFunctionLoop(rate_publish_camera_images, rate)
         # depth_publish_thread = ThreadedFunctionLoop(rate_publish_depth_images, rate)
         update_tasks_thread = ThreadedFunctionLoop(self.spot_wrapper.updateTasks, rate)
         feedback_thread = ThreadedFunctionLoop(rate_limited_feedback, rate)


### PR DESCRIPTION
This branch disables the Spot ROS driver's default behavior of automatically publishing all camera data at a fixed frequency. Instead, external nodes will now query the specific cameras they care about, saving bandwidth.