### PR TITLE
Replace `spot_wrapper` with a forked version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spot_wrapper"]
-	path = spot_wrapper
-	url = git@github.com:bdaiinstitute/spot_wrapper

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spot_wrapper"]
+	path = spot_wrapper
+	url = git@github.com:Benned-H/spot_wrapper.git


### PR DESCRIPTION
Using a forked version of `spot_wrapper` will allow us to version control any fixes we need.